### PR TITLE
Always append ID

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -1,4 +1,4 @@
-import keys from 'lodash/keys';
+import { keys, merge } from 'lodash';
 
 export default function build(reducer, objectName, id) {
   const ret = {};
@@ -42,5 +42,5 @@ export default function build(reducer, objectName, id) {
     }
   }
 
-  return ret;
+  return merge(ret, { id: id });
 }

--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -1,4 +1,5 @@
-import { keys, merge } from 'lodash';
+import keys from 'lodash/keys';
+import has from 'lodash/has';
 
 export default function build(reducer, objectName, id) {
   const ret = {};
@@ -42,5 +43,9 @@ export default function build(reducer, objectName, id) {
     }
   }
 
-  return merge(ret, { id: id });
+  if (!has(ret.id)) {
+    ret.id = id.toString();
+  }
+
+  return ret;
 }

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -80,10 +80,10 @@ describe('build works', () => {
   });
 
   it('assigns id as attribute', () => {
-    expect(object.id).to.be.equal(2620);
+    expect(object.id).to.be.equal('2620');
   });
 
-  it('assigns id as integer', () => {
-    expect(object.id).isNumber;
+  it('assigns correct id when in attribute', () => {
+    expect(object.daQuestion.id).to.be.equal('295');
   });
 });

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -82,4 +82,8 @@ describe('build works', () => {
   it('assigns id as attribute', () => {
     expect(object.id).to.be.equal(2620);
   });
+
+  it('assigns id as integer', () => {
+    expect(object.id).isNumber;
+  });
 });

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -9,7 +9,6 @@ describe('build works', () => {
       "2620": {
         attributes: {
           "text": "hello",
-          "id": 2620
         },
         relationships: {
           daQuestion: {
@@ -78,5 +77,9 @@ describe('build works', () => {
 
   it('works for empty relationship', () => {
     expect(isEqual(object.comments, [])).to.be.true;
+  });
+
+  it('assigns id as attribute', () => {
+    expect(object.id).to.be.equal(2620);
   });
 });


### PR DESCRIPTION
Looking at the JSONAPI examples (http://jsonapi.org/examples/), it seems that an objects ID always sits in the root, and not in the attributes object.

```json
HTTP/1.1 200 OK
Content-Type: application/vnd.api+json
{
  "data": [{
    "type": "articles",
    "id": "1", <- ID
    "attributes": {
      "title": "JSON API paints my bikeshed!",
      "body": "The shortest article. Ever."
    },
    "relationships": {
      "author": {
        "data": {"id": "42", "type": "people"}
      }
    }
  }],
  "included": [
    {
      "type": "people",
      "id": "42",
      "attributes": {
        "name": "John"
      }
    }
  ]
}
```
The PR simply merges the id from the params to the object, to guarantee the ID is included.

I'm not sure if it would be better/necessary to cast the ID to an Integer (I suck at JS), but I'll look into that if required.

Let me know what you think.