### PR TITLE
Revise lazy loading error message for compactness

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -17,12 +17,7 @@ function buildRelationship(reducer, target, relationship, options) {
     }
     return build(reducer, rel.data.type, rel.data.id, options);
   } else if (!ignoreLinks && rel.links) {
-    throw new Error(`
-      Remote lazy loading is not implemented for redux-object. 
-      Please refer https://github.com/yury-dymov/json-api-normalizer/issues/2.
-      If you would like to disable this error, provide 'ingoreLinks: true' option to the build function like below:
-      build(reducer, type, id, { ignoreLinks: true })
-    `);
+    throw new Error('Remote lazy loading is not supported (see: https://github.com/yury-dymov/json-api-normalizer/issues/2). To disable this error, include option \'ignoreLinks: true\' in the build function like so: build(reducer, type, id, { ignoreLinks: true })');
   }
 
   return [];


### PR DESCRIPTION
The message as designed is a little verbose, and indented for display in the IDE in such a way that adds undesired new lines and spacing during runtime display. This edit makes the error smaller, saving a few bytes in the package size. It also corrects a typo in the build() call example.