### PR TITLE
Add option to include 'type' on output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If ID is provided in a form of array, multiple objects are fetched. If ID is nul
 |:--------|:---------------:|:-------------|
 | eager | false | Controls lazy loading for the child relationship objects. By default, lazy loading is enabled. |
 | ignoreLinks | false | redux-object doesn't support remote objects. This option suppresses the exception thrown in case user accesses a property, which is not loaded to redux store yet. |
+| includeType | false | Include the record type as a property 'type' on each result. This is particularly useful for identifying the record type returned by a polymorphic relationship. |
 
 
 ```JavaScript

--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -28,9 +28,9 @@ function buildRelationship(reducer, target, relationship, options, cache) {
 
 
 export default function build(reducer, objectName, id = null, providedOpts = {}, cache = {}) {
-  const defOpts = { eager: false, ignoreLinks: false };
+  const defOpts = { eager: false, ignoreLinks: false, includeType: false };
   const options = Object.assign({}, defOpts, providedOpts);
-  const { eager } = options;
+  const { eager, includeType } = options;
 
   if (!reducer[objectName]) {
     return null;
@@ -62,6 +62,10 @@ export default function build(reducer, objectName, id = null, providedOpts = {},
   }
 
   Object.keys(target.attributes).forEach((key) => { ret[key] = target.attributes[key]; });
+
+  if (includeType && !ret.type) {
+    ret.type = objectName;
+  }
 
   cache[uuid] = ret;
 

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -276,3 +276,16 @@ describe('remote lazy loading', () => {
     return expect(isEqual(question.movie, [])).to.be.true;
   });
 });
+
+describe('Include object type', () => {
+  const local = Object.assign({}, json);
+  const object = build(local, 'post', 2620, { includeType: true });
+
+  it('should include object type on base', () => {
+    expect(object.type).to.be.equal('post');
+  });
+
+  it('should include object type on relationships', () => {
+    expect(object.daQuestion.type).to.be.equal('question');
+  });
+});

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -1,90 +1,88 @@
 import { expect } from 'chai';
-import build from '../dist/bundle';
 import isEqual from 'lodash/isEqual';
+import build from '../dist/bundle';
 
-describe('build works', () => {
-  const json = {
+const json = {
     post: {
-      "2620": {
-        id: 2620,
-        attributes: {
-          "text": "hello",
-        },
-        relationships: {
-          daQuestion: {
-            data: {
-              id: "295",
-              type: "question"
-            }
-          },
-          missingRelationship: {
-            data: {
-              id: "296",
-              type: "question"
-            }
-          },
-          liker: {
-            data: [{
-              id: "1",
-              type: "user"
-            },{
-              id: "2",
-              type: "user"
-            },{
-              id: "3",
-              type: "user"
-            }]
-          },
-          comments: {
-            data: []
-          },
-          author: {
-            data: null
-          }
+        "2620": {
+            id: 2620,
+            attributes: {
+                "text": "hello",
+            },
+            relationships: {
+                daQuestion: {
+                    data: {
+                        id: "295",
+                        type: "question"
+                    }
+                },
+                missingRelationship: {
+                    data: {
+                        id: "296",
+                        type: "question"
+                    }
+                },
+                liker: {
+                    data: [{
+                        id: "1",
+                        type: "user"
+                    },{
+                        id: "2",
+                        type: "user"
+                    },{
+                        id: "3",
+                        type: "user"
+                    }]
+                },
+                comments: {
+                    data: []
+                },
+                author: {
+                    data: null
+                }
 
+            }
         }
-      }
     },
     question: {
-      "295": {
-        attributes: {
-          text: "hello?"
+        "295": {
+            attributes: {
+                text: "hello?"
+            }
         }
-      }
     },
     user: {
-      "1": {
-        attributes: {
-	      id: 1,
-          text: "hello?"
+        "1": {
+            attributes: {
+                id: 1,
+                text: "hello?"
+            }
+        },
+        "2": {
+            attributes: {
+                text: "hello?"
+            }
+        },
+        "3": {
+            attributes: {
+                text: "hello?"
+            }
+        },
+        "4": {
+            attributes: {
+            }
         }
-      },
-      "2": {
-        attributes: {
-          text: "hello?"
-        }
-      },
-      "3": {
-        attributes: {
-          text: "hello?"
-        }
-      },
-      "4": {
-        attributes: {
-        }
-      }
     },
     meta: {
-      'posts/me': {
-        data: {
-          post: '2620'
+        'posts/me': {
+            data: {
+                post: '2620'
+            }
         }
-      }
     }
-  };
+};
 
-  
-
+describe('build single object', () => {
   const object = build(json, 'post', 2620);
 
   it('attributes', () => {
@@ -141,6 +139,46 @@ describe('build works', () => {
     const target = { id: "4" };
 
     expect(user).to.be.eql(target);
+  });
+});
+
+describe('build all objects in collection', () => {
+  const list = build(json, 'user');
+
+  it('returns an array', () => {
+    expect(list).to.be.instanceOf(Array);
+  });
+
+  it('returns all items', () => {
+    expect(list.length).to.be.equal(4);
+  });
+
+  it('includes attributes', () => {
+    expect(list[0].text).to.be.equal('hello?');
+  });
+});
+
+describe('build a specific list of objects in collection', () => {
+  const list = build(json, 'user', [2, 4]);
+
+  it('returns an array', () => {
+    expect(list).to.be.instanceOf(Array);
+  });
+
+  it('returns only selected items', () => {
+    expect(list.length).to.be.equal(2);
+    expect(list[0].id).to.be.equal('2');
+    expect(list[1].id).to.be.equal('4');
+  });
+
+  it('includes attributes', () => {
+    expect(list[0].text).to.be.equal('hello?');
+  });
+
+  it('returns a null result for requested items which are not present', () => {
+    const extra = build(json, 'user', [2, 4, 5]);
+    expect(extra.length).to.be.equal(3);
+    expect(extra[2]).to.be.equal(null);
   });
 });
 
@@ -202,6 +240,11 @@ describe('remote lazy loading', () => {
 
     it('should not throw exception', () => {
         const question = build(sourceWithData, 'question', 29);
+        return expect(isEqual(question.movie, [])).to.be.true;
+    });
+
+    it('should ignore remote lazy loading links', () => {
+        const question = build(sourceWithData, 'question', 29, false, true);
         return expect(isEqual(question.movie, [])).to.be.true;
     });
 });

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -1,112 +1,115 @@
-import { expect } from 'chai';
+import {expect} from 'chai';
 import isEqual from 'lodash/isEqual';
+import isFunction from 'lodash/isFunction';
 import build from '../dist/bundle';
 
 const json = {
-    post: {
-        "2620": {
-            id: 2620,
-            attributes: {
-                "text": "hello",
-            },
-            relationships: {
-                daQuestion: {
-                    data: {
-                        id: "295",
-                        type: "question"
-                    }
-                },
-                missingRelationship: {
-                    data: {
-                        id: "296",
-                        type: "question"
-                    }
-                },
-                liker: {
-                    data: [{
-                        id: "1",
-                        type: "user"
-                    },{
-                        id: "2",
-                        type: "user"
-                    },{
-                        id: "3",
-                        type: "user"
-                    }]
-                },
-                comments: {
-                    data: []
-                },
-                author: {
-                    data: null
-                }
+  post: {
+    "2620": {
+      id: 2620,
+      attributes: {
+        "text": "hello",
+      },
+      relationships: {
+        daQuestion: {
+          data: {
+            id: "295",
+            type: "question"
+          }
+        },
+        missingRelationship: {
+          data: {
+            id: "296",
+            type: "question"
+          }
+        },
+        liker: {
+          data: [{
+            id: "1",
+            type: "user"
+          }, {
+            id: "2",
+            type: "user"
+          }, {
+            id: "3",
+            type: "user"
+          }]
+        },
+        comments: {
+          data: []
+        },
+        author: {
+          data: null
+        }
 
-            }
-        }
-    },
-    question: {
-        "295": {
-            attributes: {
-                text: "hello?"
-            }
-        }
-    },
-    user: {
-        "1": {
-            attributes: {
-                id: 1,
-                text: "hello?"
-            }
-        },
-        "2": {
-            attributes: {
-                text: "hello?"
-            }
-        },
-        "3": {
-            attributes: {
-                text: "hello?"
-            }
-        },
-        "4": {
-            attributes: {
-            }
-        }
-    },
-    meta: {
-        'posts/me': {
-            data: {
-                post: '2620'
-            }
-        }
+      }
     }
+  },
+  question: {
+    "295": {
+      attributes: {
+        text: "hello?"
+      }
+    }
+  },
+  user: {
+    "1": {
+      attributes: {
+        id: 1,
+        text: "hello?"
+      }
+    },
+    "2": {
+      attributes: {
+        text: "hello?"
+      }
+    },
+    "3": {
+      attributes: {
+        text: "hello?"
+      }
+    },
+    "4": {
+      attributes: {}
+    }
+  },
+  meta: {
+    'posts/me': {
+      data: {
+        post: '2620'
+      }
+    }
+  }
 };
 
 describe('build single object', () => {
-  const object = build(json, 'post', 2620);
+  const local = Object.assign({}, json);
+  const object = build(local, 'post', 2620);
 
   it('attributes', () => {
     expect(object.text).to.be.equal('hello');
-  });
-
-  it('relationship', () => {
-    expect(object.daQuestion.text).to.be.equal('hello?');
   });
 
   it('many relationships', () => {
     expect(object.liker.length).to.be.equal(3);
   });
 
+  it('relationship', () => {
+    expect(object.liker[0].text).to.be.equal('hello?');
+  });
+
   it('caching works', () => {
-    expect(object.daQuestion.text).to.be.equal('hello?');
-    expect(object.daQuestion.text).to.be.equal('hello?');
+    local.question[295].attributes.text = 'Goodbye.';
+    expect(object.daQuestion.text).to.be.equal('Goodbye.');
+    local.question[295].attributes.text = 'See ya.';
+    expect(object.daQuestion.text).to.be.equal('Goodbye.');
   });
 
   it('works for empty array relationship', () => {
     expect(isEqual(object.comments, [])).to.be.true;
   });
 
-    it('works for empty relationship', () => {
+  it('works for empty relationship', () => {
     expect(isEqual(object.author, null)).to.be.true;
   });
 
@@ -119,13 +122,13 @@ describe('build single object', () => {
   });
 
   it('id in attributes is not overwritten by merge', () => {
-    const user = build(json, 'user', 1);
+    const user = build(local, 'user', 1);
 
     expect(user.id).to.be.equal(1); // and not '1'
   });
 
   it('missing object should return null', () => {
-    const user = build(json, 'user', 30);
+    const user = build(local, 'user', 30);
 
     expect(user).to.be.equal(null);
   });
@@ -135,15 +138,16 @@ describe('build single object', () => {
   });
 
   it('object with no attributes still should be an object', () => {
-    const user = build(json, 'user', 4);
-    const target = { id: "4" };
+    const user = build(local, 'user', 4);
+    const target = {id: "4"};
 
     expect(user).to.be.eql(target);
   });
 });
 
 describe('build all objects in collection', () => {
-  const list = build(json, 'user');
+  const local = Object.assign({}, json);
+  const list = build(local, 'user');
 
   it('returns an array', () => {
     expect(list).to.be.instanceOf(Array);
@@ -159,7 +163,8 @@ describe('build all objects in collection', () => {
 });
 
 describe('build a specific list of objects in collection', () => {
-  const list = build(json, 'user', [2, 4]);
+  const local = Object.assign({}, json);
+  const list = build(local, 'user', [2, 4]);
 
   it('returns an array', () => {
     expect(list).to.be.instanceOf(Array);
@@ -176,75 +181,85 @@ describe('build a specific list of objects in collection', () => {
   });
 
   it('returns a null result for requested items which are not present', () => {
-    const extra = build(json, 'user', [2, 4, 5]);
+    const extra = build(local, 'user', [2, 4, 5]);
     expect(extra.length).to.be.equal(3);
-    expect(extra[2]).to.be.equal(null);
+    expect(extra[2]).to.be.null;
+  });
+});
+
+describe('local eager loading', () => {
+  const local = Object.assign({}, json);
+  const object = build(local, 'post', 2620, true);
+
+  it('does not use lazy loading', () => {
+    local.question[295].attributes.text = 'Goodbye.';
+    expect(object.daQuestion.text).to.be.equal('hello?');
   });
 });
 
 describe('remote lazy loading', () => {
-    const source = {
-        question: {
-            "29": {
-                attributes: {
-                    yday: 228,
-                    text: "Какие качества Вы больше всего цените в женщинах?",
-                    slug: "tbd",
-                    id: 29
-                },
-                relationships: {
-                    movie: {
-                        links: {
-                            "self": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/relationships/movie",
-                            "related": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/movie"
-                        }
-                    }
-                }
+  const source = {
+    question: {
+      "29": {
+        attributes: {
+          yday: 228,
+          text: "Какие качества Вы больше всего цените в женщинах?",
+          slug: "tbd",
+          id: 29
+        },
+        relationships: {
+          movie: {
+            links: {
+              "self": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/relationships/movie",
+              "related": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/movie"
             }
+          }
         }
-    };
+      }
+    }
+  };
 
-    const sourceWithData = {
-        question: {
-            "29": {
-                attributes: {
-                    yday: 228,
-                    text: "Какие качества Вы больше всего цените в женщинах?",
-                    slug: "tbd",
-                    id: 29
-                },
-                relationships: {
-                    movie: {
-                        data: [],
-                        links: {
-                            "self": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/relationships/movie",
-                            "related": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/movie"
-                        }
-                    }
-                }
+  const sourceWithData = {
+    question: {
+      "29": {
+        attributes: {
+          yday: 228,
+          text: "Какие качества Вы больше всего цените в женщинах?",
+          slug: "tbd",
+          id: 29
+        },
+        relationships: {
+          movie: {
+            data: [],
+            links: {
+              "self": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/relationships/movie",
+              "related": "http://localhost:3000/api/v1/actor/1c9d234b-66c4-411e-b785-955d57db5536/movie"
             }
+          }
         }
-    };
+      }
+    }
+  };
 
-    it('should throw exception', () => {
-        const question = build(source, 'question', 29);
+  it('should throw exception', () => {
+    const question = build(source, 'question', 29);
 
-        try {
-            question.movie;
-        } catch (er) {
-            return expect(er.message).to.be.equal('Remote lazy loading is not implemented for redux-object. Please refer https://github.com/yury-dymov/json-api-normalizer/issues/2');
-        }
+    try {
+      question.movie;
+    } catch (er) {
+      return expect(er.message).to.be.equal('Remote lazy loading is not implemented for redux-object. Please refer https://github.com/yury-dymov/json-api-normalizer/issues/2');
+    }
 
-        throw new Error('test failed');
-    });
+    throw new Error('test failed');
+  });
 
-    it('should not throw exception', () => {
-        const question = build(sourceWithData, 'question', 29);
-        return expect(isEqual(question.movie, [])).to.be.true;
-    });
+  it('should not throw exception', () => {
+    const question = build(sourceWithData, 'question', 29);
+    return expect(isEqual(question.movie, [])).to.be.true;
+  });
 
-    it('should ignore remote lazy loading links', () => {
-        const question = build(sourceWithData, 'question', 29, false, true);
-        return expect(isEqual(question.movie, [])).to.be.true;
-    });
+  it('should ignore remote lazy loading links', () => {
+    const question = build(sourceWithData, 'question', 29, false, true);
+    return expect(isEqual(question.movie, [])).to.be.true;
+  });
 });


### PR DESCRIPTION
Per this suggestion: https://github.com/yury-dymov/redux-object/issues/16

On a polymorphic relationship, there is no way to programmatically determine the model type. This adds an option to include the object type as a property 'type'. Use of this option requires the user to treat the attribute 'type' as reserved and not allowed. In the case of a collision, the object 'type' is not included in favor of the attribute 'type'.