### PR TITLE
Return relationship object by default for missing resources.

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -14,11 +14,11 @@ function buildRelationship(reducer, target, relationship, options, cache) {
 
   if (typeof rel.data !== 'undefined') {
     if (Array.isArray(rel.data)) {
-      return rel.data.map(child => build(reducer, child.type, child.id, options, cache));
+      return rel.data.map(child => build(reducer, child.type, child.id, options, cache) || child);
     } else if (rel.data === null) {
       return null;
     }
-    return build(reducer, rel.data.type, rel.data.id, options, cache);
+    return build(reducer, rel.data.type, rel.data.id, options, cache) || rel.data;
   } else if (!ignoreLinks && rel.links) {
     throw new Error('Remote lazy loading is not supported (see: https://github.com/yury-dymov/json-api-normalizer/issues/2). To disable this error, include option \'ignoreLinks: true\' in the build function like so: build(reducer, type, id, { ignoreLinks: true })');
   }

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import isEqual from 'lodash/isEqual';
 import isFunction from 'lodash/isFunction';
+import cloneDeep from 'lodash/cloneDeep';
 import build from '../dist/bundle';
 
 const json = {
@@ -22,6 +23,15 @@ const json = {
             id: "296",
             type: "question"
           }
+        },
+        missingAndPresent: {
+          data: [{
+            id: "295",
+            type: "question"
+          }, {
+            id: "296",
+            type: "question"
+          }]
         },
         liker: {
           data: [{
@@ -91,7 +101,7 @@ const json = {
 };
 
 describe('build single object', () => {
-  const local = Object.assign({}, json);
+  const local = cloneDeep(json);
   const object = build(local, 'post', 2620);
 
   it('attributes', () => {
@@ -141,8 +151,15 @@ describe('build single object', () => {
     expect(user).to.be.equal(null);
   });
 
-  it('missing relationship should be null', () => {
-    expect(object.missingRelationship).to.be.equal(null);
+  it('missing relationship should return the relationship object', () => {
+    expect(object.missingRelationship).to.deep.equal({ id: '296', type: 'question' });
+  });
+
+  it('missing array relationship should return the relationship data array', () => {
+    expect(object.missingAndPresent).to.deep.equal([
+      object.daQuestion,
+      { id: '296', type: 'question' }
+    ]);
   });
 
   it('object with no attributes still should be an object', () => {
@@ -154,7 +171,7 @@ describe('build single object', () => {
 });
 
 describe('build all objects in collection', () => {
-  const local = Object.assign({}, json);
+  const local = cloneDeep(json);
   const list = build(local, 'user');
 
   it('returns an array', () => {
@@ -171,7 +188,7 @@ describe('build all objects in collection', () => {
 });
 
 describe('build a specific list of objects in collection', () => {
-  const local = Object.assign({}, json);
+  const local = cloneDeep(json);
   const list = build(local, 'user', [2, 4]);
 
   it('returns an array', () => {
@@ -196,7 +213,7 @@ describe('build a specific list of objects in collection', () => {
 });
 
 describe('local eager loading', () => {
-  const local = Object.assign({}, json);
+  const local = cloneDeep(json);
   const object = build(local, 'post', 2620, { eager: true });
 
   it('does not use lazy loading', () => {
@@ -278,7 +295,7 @@ describe('remote lazy loading', () => {
 });
 
 describe('Include object type', () => {
-  const local = Object.assign({}, json);
+  const local = cloneDeep(json);
   const object = build(local, 'post', 2620, { includeType: true });
 
   it('should include object type on base', () => {


### PR DESCRIPTION
When requesting relationship data not included in the store, it currently returns null. Instead it should return the relationship object itself, so that you can access the id.

**Note** I'll let you figure this out, but you might want to introduce this as a breaking change. I could see a case where someone is currently utilizing the fact that non-loaded relationships are `null` as a potential feature.

Fixes #18 