### PR TITLE
Make private cache attributes not enumerable

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -90,7 +90,8 @@ export default function build(reducer, objectName, id = null, providedOpts = {},
                 return ret[field];
               }
 
-              ret[field] = buildRelationship(reducer, target, relationship, options, cache);
+              const value = buildRelationship(reducer, target, relationship, options, cache);
+              Object.defineProperty(ret, field, { enumerable: false, value });
 
               return ret[field];
             },

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -159,6 +159,20 @@ describe('build single object', () => {
     expect(object.liker[0].propertyIsEnumerable('text')).to.be.true;
   });
 
+  it('only enumerates public attributes', () => {
+    expect(Object.keys(object).sort()).to.deep.equal([
+      'author',
+      'comments',
+      'daQuestion',
+      'id',
+      'liker',
+      'meta',
+      'missingAndPresent',
+      'missingRelationship',
+      'text',
+    ]);
+  });
+
   it('missing object should return null', () => {
     const user = build(local, 'user', 30);
 


### PR DESCRIPTION
When not eager-loading relationships, these are defined as properties with a getter that only builds the relationship data structure if requested. Once built, it keeps the built data structure in what can be called a private attribute of sorts.

This commit make these private attributes not enumerable. This has a number of benefits, mainly around not having this attributes show up when listing all keys of the object, which in turn helps with
comparisons of this object with others, etc.