### PR TITLE
Validate `attributes`  in top-level member

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -61,8 +61,10 @@ export default function build(reducer, objectName, id = null, providedOpts = {},
     ret.id = target.id;
   }
 
-  Object.keys(target.attributes).forEach((key) => { ret[key] = target.attributes[key]; });
-
+  if (target.attributes) {
+    Object.keys(target.attributes).forEach((key) => { ret[key] = target.attributes[key]; });
+  }
+  
   if (target.meta) {
     ret.meta = target.meta;
   }


### PR DESCRIPTION
According to the [JSON API specification](http://jsonapi.org/format/#document-resource-objects), a resource object **MAY** contain an `attributes` top-level member.

This change brings redux-object closer to the spec by first checking the presence of `attributes` instead of assuming it.