### PR TITLE
Include resource links

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -97,6 +97,10 @@ export default function build(reducer, objectName, id = null, providedOpts = {},
     ret.meta = target.meta;
   }
 
+  if (target.links) {
+    ret.links = target.links;
+  }
+
   if (includeType && !ret.type) {
     ret.type = objectName;
   }

--- a/test/redux-object.spec.js
+++ b/test/redux-object.spec.js
@@ -11,6 +11,9 @@ const json = {
       attributes: {
         "text": "hello",
       },
+      links: {
+        "self": "http://example.com/posts/2620"
+      },
       meta: {
         'like-count': 49
       },
@@ -117,6 +120,10 @@ const runTests = (jsonFunc, description, allowMutations = true) => {
         expect(object.meta['like-count']).to.be.equal(49);
       });
 
+      it('resource links', () => {
+        expect(object.links.self).to.be.equal('http://example.com/posts/2620');
+      });
+
       it('many relationships', () => {
         expect(object.liker.length).to.be.equal(3);
       });
@@ -173,6 +180,7 @@ const runTests = (jsonFunc, description, allowMutations = true) => {
           'daQuestion',
           'id',
           'liker',
+          'links',
           'meta',
           'missingAndPresent',
           'missingRelationship',


### PR DESCRIPTION
According to JSON:API documentation (https://jsonapi.org/format/#document-resource-objects) Resource objects MAY include `links` object. This PR implements this feature.