### PR TITLE
Set object as resolved if there are attributes

### DIFF
--- a/src/redux-object.js
+++ b/src/redux-object.js
@@ -96,6 +96,7 @@ export default function build(reducer, objectName, id = null, providedOpts = {},
 
   if (target.attributes) {
     Object.keys(target.attributes).forEach((key) => { ret[key] = target.attributes[key]; });
+    ret.__resolved = true;
   }
 
   if (target.meta) {


### PR DESCRIPTION
This PR marks all target objects with `__resolved = true` if they contain `attributes`. It addresses the problem discussed in https://github.com/yury-dymov/redux-object/issues/29. Now it is possible to differentiate between _not yet loaded_ objects/relationships and loaded ones.  